### PR TITLE
Add depend_on_asset to fix error in rails 4.1

### DIFF
--- a/app/assets/stylesheets/semantic-ui.scss
+++ b/app/assets/stylesheets/semantic-ui.scss
@@ -1,3 +1,20 @@
+//= depend_on_asset "semantic-ui/loader-large.gif"
+//= depend_on_asset "semantic-ui/loader-medium.gif"
+//= depend_on_asset "semantic-ui/loader-small.gif"
+//= depend_on_asset "semantic-ui/loader-mini.gif"
+//= depend_on_asset "semantic-ui/loader-large-inverted.gif"
+//= depend_on_asset "semantic-ui/loader-medium-inverted.gif"
+//= depend_on_asset "semantic-ui/loader-small-inverted.gif"
+//= depend_on_asset "semantic-ui/loader-mini-inverted.gif"
+//= depend_on_asset "semantic-ui/basic.icons.eot"
+//= depend_on_asset "semantic-ui/basic.icons.svg"
+//= depend_on_asset "semantic-ui/basic.icons.woff"
+//= depend_on_asset "semantic-ui/basic.icons.ttf"
+//= depend_on_asset "semantic-ui/icons.eot"
+//= depend_on_asset "semantic-ui/icons.svg"
+//= depend_on_asset "semantic-ui/icons.woff"
+//= depend_on_asset "semantic-ui/icons.ttf"
+
 @import 'semantic-ui/collections/all';
 @import 'semantic-ui/elements/all';
 @import 'semantic-ui/modules/all';


### PR DESCRIPTION
fixes #9

Won't work for users that just include sub-modules though. Not sure what a good fix for those cases is.
