### PR TITLE
Removes reference to a absent icon file

### DIFF
--- a/app/assets/stylesheets/semantic-ui/elements/_icon.scss
+++ b/app/assets/stylesheets/semantic-ui/elements/_icon.scss
@@ -17,7 +17,7 @@
 @font-face {
   font-family: 'Icons';
   src: font-url("semantic-ui/icons.eot");
-  src: font-url("semantic-ui/icons.eot?#iefix") format('embedded-opentype'), font-url("semantic-ui/icons.woff2") format('woff'), font-url("semantic-ui/icons.woff") format('woff'), font-url("semantic-ui/icons.ttf") format('truetype'), font-url("semantic-ui/icons.svg#icons") format('svg');
+  src: font-url("semantic-ui/icons.eot?#iefix") format('embedded-opentype'), font-url("semantic-ui/icons.woff") format('woff'), font-url("semantic-ui/icons.ttf") format('truetype'), font-url("semantic-ui/icons.svg#icons") format('svg');
   font-style: normal;
   font-weight: normal;
   font-variant: normal;


### PR DESCRIPTION
This fixes absent error in sprockets when loading server using the gem version '1.11.4.0'.