### PR TITLE
convert Google Font import to CSS @import

### DIFF
--- a/app/assets/stylesheets/semantic-ui/globals/_site.scss
+++ b/app/assets/stylesheets/semantic-ui/globals/_site.scss
@@ -14,7 +14,7 @@
              Page
 *******************************/
 
-@import 'https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin';
+@import url()https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin);
 html,
 body {
   height: 100%;


### PR DESCRIPTION
treat Google Font import as css @import to avoid SCSS from attempting to parse it.