### PR TITLE
Add latin-ext subset to Google Font import URL.

### DIFF
--- a/app/assets/stylesheets/semantic-ui/globals/_site.scss
+++ b/app/assets/stylesheets/semantic-ui/globals/_site.scss
@@ -14,7 +14,7 @@
              Page
 *******************************/
 
-@import url('https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin');
+@import url('https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin,latin-ext');
 html,
 body {
   height: 100%;
@@ -158,4 +158,3 @@ input::selection {
 /*******************************
          Site Overrides
 *******************************/
-


### PR DESCRIPTION
Fixing odd font view on letters in languages used in Eastern Europe.

I'm using `semantic-ui-sass` in application used by client from Poland. Font looks really odd with specific polish letters.

For example:
![screen shot 2016-05-26 at 16 46 12](https://cloud.githubusercontent.com/assets/218911/15578620/73f32980-2361-11e6-9b4d-1b8daf0bb761.png)

With this small fix:
![screen shot 2016-05-26 at 16 46 30](https://cloud.githubusercontent.com/assets/218911/15578627/7ca7821a-2361-11e6-922d-1d3f52aa524f.png)

Thank you for considering this small PR.