### PR TITLE
Fix undefined method `start_with?' for /semantic-ui\/(basic\.)*icons\.(?:eot|svg|ttf|woff)$/:Regexp

### DIFF
--- a/lib/semantic/ui/sass/engine.rb
+++ b/lib/semantic/ui/sass/engine.rb
@@ -5,7 +5,7 @@ module Semantic
       module Rails
         class Engine < ::Rails::Engine
           initializer "semantic-ui-sass.assets.precompile" do |app|
-            if ::Rails.version >= '5'
+            if ::Rails.version >= '5' || ::Sprockets::VERSION.start_with?('4')
               ::Rails.application.config.assets.precompile += %w{ semantic-ui/*icons.* }
             else
               app.config.assets.precompile << %r(semantic-ui\/(basic\.)*icons\.(?:eot|svg|ttf|woff)$)


### PR DESCRIPTION
Hi guys, 

this is fix for already closed #68.

I found out that this is not only problem with `rails 5` which probably uses new `sprockets` but this is problem with sprockets 4 themselves. 

My setup is:
rails (= 4.2.5.2)
sprockets (4.0.0.beta2)
semantic-ui-sass (2.2.1.0)

EDIT: I left there rails 5 conditional since [master rails](https://github.com/rails/rails/blob/master/rails.gemspec#L32) does not necessarily depend on newest sprockets explicitly