### PR TITLE
Add $import-google-fonts variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $font-url: 'http://fonts.useso.com/css?family=Lato:400,700,400italic,700italic&s
 
 ## Skip font loading
 ```css
-$importGoogleFonts: false;
+$import-google-fonts: false;
 @import 'semantic-ui';
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ $font-url: 'http://fonts.useso.com/css?family=Lato:400,700,400italic,700italic&s
 @import 'semantic-ui';
 ```
 
+## Skip font loading
+```css
+$importGoogleFonts: false;
+@import 'semantic-ui';
+```
+
 ## Javascripts
 
 We have a helper that includes all Semantic javascripts. Put this in your Javascript manifest (usually in `application.js`) to

--- a/app/assets/stylesheets/semantic-ui/globals/_site.scss
+++ b/app/assets/stylesheets/semantic-ui/globals/_site.scss
@@ -13,7 +13,10 @@
              Page
 *******************************/
 
-@import url($font-url);
+@if $importGoogleFonts {
+  @import url($font-url);
+}
+
 html,
 body {
   height: 100%;

--- a/app/assets/stylesheets/semantic-ui/globals/_site.scss
+++ b/app/assets/stylesheets/semantic-ui/globals/_site.scss
@@ -13,7 +13,7 @@
              Page
 *******************************/
 
-@if $importGoogleFonts {
+@if $import-google-fonts {
   @import url($font-url);
 }
 

--- a/app/assets/stylesheets/semantic-ui/globals/_variables.scss
+++ b/app/assets/stylesheets/semantic-ui/globals/_variables.scss
@@ -1,3 +1,4 @@
+$importGoogleFonts: true !default;
 $font-url: 'https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin,latin-ext' !default;
 $font-name: 'Lato' !default;
 $font-family: $font-name, 'Helvetica Neue', Arial, Helvetica, sans-serif !default;

--- a/app/assets/stylesheets/semantic-ui/globals/_variables.scss
+++ b/app/assets/stylesheets/semantic-ui/globals/_variables.scss
@@ -1,4 +1,4 @@
-$importGoogleFonts: true !default;
+$import-google-fonts: true !default;
 $font-url: 'https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin,latin-ext' !default;
 $font-name: 'Lato' !default;
 $font-family: $font-name, 'Helvetica Neue', Arial, Helvetica, sans-serif !default;


### PR DESCRIPTION
Add $importGoogleFonts variable support, so you can skip the Lato font importing by doing:

```css
$import-google-fonts: false;
@import 'semantic-ui';
```