### PR TITLE
Fix invalid image-url for flags.png on rails5

### DIFF
--- a/app/assets/stylesheets/semantic-ui/elements/_flag.scss
+++ b/app/assets/stylesheets/semantic-ui/elements/_flag.scss
@@ -31,7 +31,7 @@ i.flag:not(.icon) {
 i.flag:not(.icon):before {
   display: inline-block;
   content: '';
-  background: image-url("./semantic-ui/flags.png") no-repeat -108px -1976px;
+  background: image-url("semantic-ui/flags.png") no-repeat -108px -1976px;
   width: 16px;
   height: 11px;
 }


### PR DESCRIPTION
GETting `/images/semantic-ui/flags.png` gets to return 404 on my rails5 app from v2.2.7.0.
It caused by the change made in 5cd1b69.
Please have a look.