### PR TITLE
before_action instead before_filter. Fix deprecation warnings for Rai…

### DIFF
--- a/lib/semantic/ui/sass/breadcrumbs.rb
+++ b/lib/semantic/ui/sass/breadcrumbs.rb
@@ -10,7 +10,7 @@ module Semantic
         module ClassMethods
           def semantic_breadcrumb(name, url, options = {})
             class_name = self.name
-            before_filter options do |controller|
+            before_action options do |controller|
               name = controller.send :translate_semantic_breadcrumb, name, class_name if name.is_a?(Symbol)
               controller.send :semantic_breadcrumb, name, url
             end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -14,7 +14,7 @@ Dummy::Application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_assets  = true
-  config.static_cache_control = "public, max-age=3600"
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
Fix Rails 5.0 deprecation warning message about `before_filter` in Rails 5.1