### PR TITLE
Updates the Ruby README.md installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The gem only has default theme.
 ## Installation and Usage
 
 ```ruby
-gem 'semantic-ui-sass'
+gem install 'semantic-ui-sass'
 ```
 
 `bundle install` and restart your server to make the files available through the pipeline.


### PR DESCRIPTION
Executing `gem 'semantic-ui-sass'` will give the following error below.
`
ERROR:  While executing gem ... (Gem::CommandLineError)
Unknown command semantic-ui-sass
`

Adding `install` fixes this issue. 