### PR TITLE
Adding CHANGELOG file entry for 2.4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,369 +1,372 @@
+## 2.4.3.0
+
+- Change from `sass-rails` to `sassc-rails` to correct deprecation usage
+
 ## 2.4.2.0
 
-* Update Semantic UI to 2.4.2
-* Add $use-custom-scrollbar variable to optionally use native scrollbars #138
+- Update Semantic UI to 2.4.2
+- Add $use-custom-scrollbar variable to optionally use native scrollbars #138
 
 ## 2.4.0.1
 
-* Include new placeholder element #133
+- Include new placeholder element #133
 
 ## 2.4.0.0
 
-* Update Semantic UI to 2.4.0
+- Update Semantic UI to 2.4.0
 
 ## 2.3.3.0
 
-* Update Semantic UI to 2.3.3
+- Update Semantic UI to 2.3.3
 
 ## 2.3.1.2
 
-* update icons font
+- update icons font
 
 ## 2.3.1.1
 
-* add missing brand-icon files #128
+- add missing brand-icon files #128
 
 ## 2.3.1.0
 
-* Update Semantic UI to 2.3.1
+- Update Semantic UI to 2.3.1
 
 ## 2.3.0.0
 
-* Update Semantic UI to 2.3.0
+- Update Semantic UI to 2.3.0
 
 ## 2.2.14
 
-* Update Semantic UI to 2.2.14
+- Update Semantic UI to 2.2.14
 
 ## 2.2.12.1
 
-* Add sprockets support #120
+- Add sprockets support #120
 
 ## 2.2.10.1
 
-* Fix flag.png path
+- Fix flag.png path
 
 ## 2.2.10.0
 
-* Update Semantic UI to 2.2.10
+- Update Semantic UI to 2.2.10
 
 ## 2.2.9.3
 
-* Fix semantic-ui.js require statements
+- Fix semantic-ui.js require statements
 
 ## 2.2.9.2
 
-* Update semantic-ui.js to 2.2.9
+- Update semantic-ui.js to 2.2.9
 
 ## 2.2.9.1
 
-* Fix compass template error
+- Fix compass template error
 
 ## 2.2.9.0
 
-* before_action instead before_filter
+- before_action instead before_filter
 
-* Update Semantic UI to 2.2.9
+- Update Semantic UI to 2.2.9
 
 ## 2.2.7.1
 
-* Fix invalid image-url for flags.png
+- Fix invalid image-url for flags.png
 
 ## 2.2.7.0
 
-* Replace flags image with optimized one
+- Replace flags image with optimized one
 
-* Change gem install to secure HTTPS URL
+- Change gem install to secure HTTPS URL
 
-* Update Semantic UI to 2.2.7
+- Update Semantic UI to 2.2.7
 
 ## 2.2.6.0
 
-* Add import-google-fonts variable
+- Add import-google-fonts variable
 
-* Update Semantic UI to 2.2.6
+- Update Semantic UI to 2.2.6
 
 ## 2.2.4.0
 
-* Update Semantic UI to 2.2.4
+- Update Semantic UI to 2.2.4
 
 ## 2.2.3.0
 
-* Add font-name variable to change easily custom fonts
-* Fix undefined method `start_with?` for sprockets 4
-* Add font-family variable
-* Update Semantic UI to 2.2.3
+- Add font-name variable to change easily custom fonts
+- Fix undefined method `start_with?` for sprockets 4
+- Add font-family variable
+- Update Semantic UI to 2.2.3
 
 ## 2.2.2.2
 
-* Update fonts to version 2.2.2 #81
+- Update fonts to version 2.2.2 #81
 
 ## 2.2.2.1
 
-* Add font-url variable
+- Add font-url variable
 
 ## 2.2.2.0
 
-* Update Semantic UI to 2.2.2
+- Update Semantic UI to 2.2.2
 
 ## 2.2.1.1
 
-* Fix #79
+- Fix #79
 
 ## 2.2.1.0
 
-* Update Semantic UI to 2.2.1
-* Fixed font url error #78
+- Update Semantic UI to 2.2.1
+- Fixed font url error #78
 
 ## 2.2.0.0
 
-* Update Semantic UI to 2.2.0
-* Fixed rails 5 error
-* Allow any HTML options in semantic_icon
-* Add latin-ext subset to Google Font import URL.
+- Update Semantic UI to 2.2.0
+- Fixed rails 5 error
+- Allow any HTML options in semantic_icon
+- Add latin-ext subset to Google Font import URL.
 
 ## 2.1.8.0
 
-* Update Semantic UI to 2.1.8
+- Update Semantic UI to 2.1.8
 
 ## 2.1.6.0
 
-* Update Semantic UI to 2.1.6
+- Update Semantic UI to 2.1.6
 
 ## 2.1.4.0
 
-* Rename breadcrumb methods to follow semantic_ naming
+- Rename breadcrumb methods to follow semantic\_ naming
 
-* Update Semantic UI to 2.1.4
+- Update Semantic UI to 2.1.4
 
 ## 2.0.7.0
 
-* Update Semantic UI to 2.0.7
+- Update Semantic UI to 2.0.7
 
 ## 2.0.4.0
 
-* Update Semantic UI to 2.0.4
+- Update Semantic UI to 2.0.4
 
 ## 1.12.3.0
 
-* Update Semantic UI to 1.12.3
+- Update Semantic UI to 1.12.3
 
 ## 1.11.4.1
 
-* Removes reference to a absent icon file
+- Removes reference to a absent icon file
 
 ## 1.11.4.0
 
-* Update Semantic UI to 1.11.4
+- Update Semantic UI to 1.11.4
 
 ## 1.8.1.0
 
-* Update Semantic UI to 1.8.1
+- Update Semantic UI to 1.8.1
 
 ## 1.8.0.0
 
-* Update Semantic UI to 1.8.0
+- Update Semantic UI to 1.8.0
 
 ## 1.7.3.0
 
-* Update Semantic UI to 1.7.3
+- Update Semantic UI to 1.7.3
 
 ## 1.7.0.0
 
-* Update Semantic UI to 1.7.0
+- Update Semantic UI to 1.7.0
 
 ## 1.6.2.0
 
-* Update Semantic UI to 1.6.2
+- Update Semantic UI to 1.6.2
 
 ## 1.5.0.0
 
-* Update Semantic UI to 1.5.0
+- Update Semantic UI to 1.5.0
 
 ## 1.4.1.0
 
-* Update Semantic UI to 1.4.1
+- Update Semantic UI to 1.4.1
 
 ## 1.2.0.0
 
-* Update Semantic UI to 1.2.0
-
+- Update Semantic UI to 1.2.0
 
 ## 0.19.3.1
 
-* Fix fonts urls for asset pipeline
+- Fix fonts urls for asset pipeline
 
 ## 0.19.3.0
 
-* Fix font-url
+- Fix font-url
 
-* Update Semantic UI to 0.19.3
+- Update Semantic UI to 0.19.3
 
 ## 0.16.1.0
 
-* Update Semantic UI to 0.16.1
+- Update Semantic UI to 0.16.1
 
 ## 0.15.5.0
 
-* Update Semantic UI to 0.15.5
+- Update Semantic UI to 0.15.5
 
 ## 0.15.4.2
 
-* Fix netsted import error
+- Fix netsted import error
 
 ## 0.15.4.1
 
-* Fix depend_on_asset
+- Fix depend_on_asset
 
 ## 0.15.4.0
 
-* Update Semantic UI to 0.15.4
+- Update Semantic UI to 0.15.4
 
 ## 0.15.2.0
 
-* Update Semantic UI to 0.15.2
+- Update Semantic UI to 0.15.2
 
 ## 0.15.1.0
 
-* Update Semantic UI to 0.15.1
+- Update Semantic UI to 0.15.1
 
 ## 0.14.0.0
 
-* Update Semantic UI to 0.14.0
+- Update Semantic UI to 0.14.0
 
 ## 0.13.1.0
 
-* Update Semantic UI to 0.13.1
+- Update Semantic UI to 0.13.1
 
 ## 0.13.0.0
 
-* Update Semantic UI to 0.13.0
+- Update Semantic UI to 0.13.0
 
 ## 0.12.5.0
 
-* Update Semantic UI to 0.12.5
+- Update Semantic UI to 0.12.5
 
 ## 0.12.4.0
 
-* Update Semantic UI to 0.12.4
+- Update Semantic UI to 0.12.4
 
 ## 0.12.3.0
 
-* Update Semantic UI to 0.12.3
+- Update Semantic UI to 0.12.3
 
 ## 0.12.2.0
 
-* Update Semantic UI to 0.12.2
+- Update Semantic UI to 0.12.2
 
 ## 0.12.1.0
 
-* Update Semantic UI to 0.12.1
+- Update Semantic UI to 0.12.1
 
 ## 0.12.0.0
 
-* Update Semantic UI to 0.12.0
+- Update Semantic UI to 0.12.0
 
 ## 0.11.0.0
 
-* Update Semantic UI to 0.11.0
+- Update Semantic UI to 0.11.0
 
 ## 0.10.3.0
 
-* Update Semantic UI to 0.10.3
+- Update Semantic UI to 0.10.3
 
 ## 0.10.2.0
 
-* Update Semantic UI to 0.10.2
+- Update Semantic UI to 0.10.2
 
 ## 0.10.1.0
 
-* Update Semantic UI to 0.10.1
+- Update Semantic UI to 0.10.1
 
 ## 0.10.0.0
 
-* Update Semantic UI to 0.10.0
+- Update Semantic UI to 0.10.0
 
 ## 0.9.6.0
 
-* Update Semantic UI to 0.9.6
+- Update Semantic UI to 0.9.6
 
 ## 0.9.5.0
 
-* Update Semantic UI to 0.9.5
+- Update Semantic UI to 0.9.5
 
 ## 0.9.4.0
 
-* Update Semantic UI to 0.9.4
+- Update Semantic UI to 0.9.4
 
 ## 0.9.3.0
 
-* Update Semantic UI to 0.9.3
+- Update Semantic UI to 0.9.3
 
 ## 0.9.2.0
 
-* Update Semantic UI to 0.9.2
+- Update Semantic UI to 0.9.2
 
 ## 0.9.1.0
 
-* Update Semantic UI to 0.9.1
+- Update Semantic UI to 0.9.1
 
-* Add breadcrumbs helper
+- Add breadcrumbs helper
 
 ## 0.9.0.0
 
-* Update Semantic UI to 0.9.0
+- Update Semantic UI to 0.9.0
 
-* Add browsers setting for autoprefixer
+- Add browsers setting for autoprefixer
 
 ## 0.8.6.0
 
-* Update Semantic UI to 0.8.6
+- Update Semantic UI to 0.8.6
 
 ## 0.8.5.0
 
-* Update Semantic UI to 0.8.5
+- Update Semantic UI to 0.8.5
 
 ## 0.8.4.0
 
-* Update Semantic UI to 0.8.4
+- Update Semantic UI to 0.8.4
 
 ## 0.8.3.0
 
-* Update Semantic UI to 0.8.3
+- Update Semantic UI to 0.8.3
 
 ## 0.8.0.0
 
 ## 0.8.2.0
 
-* Update Semantic UI to 0.8.2
+- Update Semantic UI to 0.8.2
 
-* Add autoprefixer
+- Add autoprefixer
 
-* Remove sqlite3
+- Remove sqlite3
 
 ## 0.8.1.0
 
-* Update Semantic UI to 0.8.1
+- Update Semantic UI to 0.8.1
 
 ## 0.8.0.0
 
-* Add flash helper
+- Add flash helper
 
-* Add icon helper
+- Add icon helper
 
-* Update Semantic UI to 0.8.0
+- Update Semantic UI to 0.8.0
 
 ## 0.0.3
 
-* Fix typo in semantic-ui.js
+- Fix typo in semantic-ui.js
 
-* Update Semantic UI
+- Update Semantic UI
 
 ## 0.0.2
 
 ### Features
 
-* Add support for compass
+- Add support for compass
 
 ```console
   gem install semantic-ui-sass
@@ -372,4 +375,4 @@
 
 ## 0.0.1
 
-* Initial version
+- Initial version


### PR DESCRIPTION
This should also pull over the tag, but I can not quite figure out how to do that. Can we please run and push tags so that rubygems etc are updated?

```
git tag -a -m "Change from sass-rails to sassc-rails" 2.4.3.0
```

![Screen Shot 2021-05-18 at 09 30 34](https://user-images.githubusercontent.com/337539/118680133-b34f0600-b7bb-11eb-9ace-26c83c78167b.png)